### PR TITLE
Changes for enabling -cfcolo and allow inheriting the default config file  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,1 @@
 
-.DS_Store
-cf_ddns/CloudflareST
-cf_ddns/ip.txt
-cf_ddns/ipv6.txt
-cf_ddns/使用+错误+反馈说明.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+
+.DS_Store
+cf_ddns/CloudflareST
+cf_ddns/ip.txt
+cf_ddns/ipv6.txt
+cf_ddns/使用+错误+反馈说明.txt

--- a/cf_ddns/cf_ddns_cloudflare.sh
+++ b/cf_ddns/cf_ddns_cloudflare.sh
@@ -102,10 +102,10 @@ if [ "$IP_PR_IP" -ne "0" ] ; then
   $CloudflareST $CFST_URL_R -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM -f ./cf_ddns/pr_ip.txt -o ./cf_ddns/result.csv
 elif [ "$IP_ADDR" = "ipv6" ] ; then
   #开始优选IPv6
-  $CloudflareST $CFST_URL_R -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -tll $CFST_TLL -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM -f ./cf_ddns/ipv6.txt -o ./cf_ddns/result.csv
+  $CloudflareST $CFST_URL_R -cfcolo $CFCOLO -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -tll $CFST_TLL -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM -f ./cf_ddns/ipv6.txt -o ./cf_ddns/result.csv
 else
   #开始优选IPv4
-  $CloudflareST $CFST_URL_R -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -tll $CFST_TLL -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM -f ./cf_ddns/ip.txt -o ./cf_ddns/result.csv
+  $CloudflareST $CFST_URL_R -cfcolo $CFCOLO -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -tll $CFST_TLL -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM -f ./cf_ddns/ip.txt -o ./cf_ddns/result.csv
 fi
 echo "测速完毕";
 

--- a/cf_ddns/cf_ddns_cloudflare.sh
+++ b/cf_ddns/cf_ddns_cloudflare.sh
@@ -97,15 +97,23 @@ elif [ "$IP_PR_IP" = "2" ] ; then
     echo "已更新线路2的反向代理列表"
   fi
 fi
-  
+
+if [ -z "$CFCOLO" ]; then
+    echo "CFCOLO is empty, searching for IP globally"
+    CFCOLO_PARAM_STRING=""
+else
+    echo "Searching for IPs in ${CFCOLO}."
+    CFCOLO_PARAM_STRING="-cfcolo ${CFCOLO}"
+fi
+
 if [ "$IP_PR_IP" -ne "0" ] ; then
-  $CloudflareST $CFST_URL_R -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM -f ./cf_ddns/pr_ip.txt -o ./cf_ddns/result.csv
+  $CloudflareST $CFST_URL_R -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM CFCOLO_PARAM_STRING -f ./cf_ddns/pr_ip.txt -o ./cf_ddns/result.csv
 elif [ "$IP_ADDR" = "ipv6" ] ; then
   #开始优选IPv6
-  $CloudflareST $CFST_URL_R -cfcolo $CFCOLO -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -tll $CFST_TLL -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM -f ./cf_ddns/ipv6.txt -o ./cf_ddns/result.csv
+  $CloudflareST $CFST_URL_R -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -tll $CFST_TLL -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM CFCOLO_PARAM_STRING -f ./cf_ddns/ipv6.txt -o ./cf_ddns/result.csv
 else
   #开始优选IPv4
-  $CloudflareST $CFST_URL_R -cfcolo $CFCOLO -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -tll $CFST_TLL -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM -f ./cf_ddns/ip.txt -o ./cf_ddns/result.csv
+  $CloudflareST $CFST_URL_R -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -tll $CFST_TLL -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM CFCOLO_PARAM_STRING -f ./cf_ddns/ip.txt -o ./cf_ddns/result.csv
 fi
 echo "测速完毕";
 

--- a/cf_ddns/cf_ddns_cloudflare.sh
+++ b/cf_ddns/cf_ddns_cloudflare.sh
@@ -98,22 +98,22 @@ elif [ "$IP_PR_IP" = "2" ] ; then
   fi
 fi
 
+CFCOLO_PARAM_STRING=
 if [ -z "$CFCOLO" ]; then
     echo "CFCOLO is empty, searching for IP globally"
-    CFCOLO_PARAM_STRING=""
 else
     echo "Searching for IPs in ${CFCOLO}."
     CFCOLO_PARAM_STRING="-cfcolo ${CFCOLO}"
 fi
 
 if [ "$IP_PR_IP" -ne "0" ] ; then
-  $CloudflareST $CFST_URL_R -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM CFCOLO_PARAM_STRING -f ./cf_ddns/pr_ip.txt -o ./cf_ddns/result.csv
+  $CloudflareST $CFST_URL_R -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM -f ./cf_ddns/pr_ip.txt -o ./cf_ddns/result.csv CFCOLO_PARAM_STRING
 elif [ "$IP_ADDR" = "ipv6" ] ; then
   #开始优选IPv6
-  $CloudflareST $CFST_URL_R -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -tll $CFST_TLL -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM CFCOLO_PARAM_STRING -f ./cf_ddns/ipv6.txt -o ./cf_ddns/result.csv
+  $CloudflareST $CFST_URL_R -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -tll $CFST_TLL -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM -f ./cf_ddns/ipv6.txt -o ./cf_ddns/result.csv CFCOLO_PARAM_STRING
 else
   #开始优选IPv4
-  $CloudflareST $CFST_URL_R -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -tll $CFST_TLL -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM CFCOLO_PARAM_STRING -f ./cf_ddns/ip.txt -o ./cf_ddns/result.csv
+  $CloudflareST $CFST_URL_R -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -tll $CFST_TLL -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM -f ./cf_ddns/ip.txt -o ./cf_ddns/result.csv CFCOLO_PARAM_STRING
 fi
 echo "测速完毕";
 

--- a/cf_ddns/cf_ddns_cloudflare.sh
+++ b/cf_ddns/cf_ddns_cloudflare.sh
@@ -102,18 +102,18 @@ CFCOLO_PARAM_STRING=
 if [ -z "$CFCOLO" ]; then
     echo "CFCOLO is empty, searching for IP globally"
 else
-    echo "Searching for IPs in ${CFCOLO}."
     CFCOLO_PARAM_STRING="-cfcolo ${CFCOLO}"
+    echo "Searching for IPs in ${CFCOLO} by using ${CFCOLO_PARAM_STRING}."
 fi
 
 if [ "$IP_PR_IP" -ne "0" ] ; then
-  $CloudflareST $CFST_URL_R -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM -f ./cf_ddns/pr_ip.txt -o ./cf_ddns/result.csv CFCOLO_PARAM_STRING
+  $CloudflareST $CFST_URL_R $CFCOLO_PARAM_STRING -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM -f ./cf_ddns/pr_ip.txt -o ./cf_ddns/result.csv
 elif [ "$IP_ADDR" = "ipv6" ] ; then
   #开始优选IPv6
-  $CloudflareST $CFST_URL_R -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -tll $CFST_TLL -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM -f ./cf_ddns/ipv6.txt -o ./cf_ddns/result.csv CFCOLO_PARAM_STRING
+  $CloudflareST $CFST_URL_R $CFCOLO_PARAM_STRING -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -tll $CFST_TLL -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM -f ./cf_ddns/ipv6.txt -o ./cf_ddns/result.csv
 else
   #开始优选IPv4
-  $CloudflareST $CFST_URL_R -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -tll $CFST_TLL -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM -f ./cf_ddns/ip.txt -o ./cf_ddns/result.csv CFCOLO_PARAM_STRING
+  $CloudflareST $CFST_URL_R $CFCOLO_PARAM_STRING -t $CFST_T -n $CFST_N -dn $CFST_DN -tl $CFST_TL -dt $CFST_DT -tp $CFST_TP -tll $CFST_TLL -sl $CFST_SL -p $CFST_P -tlr $CFST_TLR $CFST_STM -f ./cf_ddns/ip.txt -o ./cf_ddns/result.csv
 fi
 echo "测速完毕";
 

--- a/config.conf
+++ b/config.conf
@@ -90,7 +90,7 @@ httping_code=
 # --匹配指定地区--
 #    地区名为当地机场三字码，英文逗号分隔，支持小写，支持 Cloudflare、AWS CloudFront，仅 HTTPing 模式可用；(默认 所有地区)
 #    例如:HKG,KHH,NRT,LAX,SEA,SJC,FRA,MAD
-cfcolo=
+CFCOLO=
 
 # --测速线程数量--
 #	越多测速越快，性能弱的设备 (如路由器) 请勿太高；(默认 200 最多 1000 )

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Default config file
 config_file="config.conf"
-
+# Source the default config file to get all default config
+source "$config_file"
 # Check if --cfg parameter is provided
 for i in "$@"
 do
@@ -10,11 +11,10 @@ do
         # Get the next argument as the config file
         shift
         config_file="$1"
+        # Source the config file given by user and modify the default
+        source "$config_file"
     fi
 done
-
-# Source the config file
-source "$config_file"
 
 source ./cf_ddns/cf_check.sh
 


### PR DESCRIPTION
There are two changes in this PR:
1: enable -cfcolo for selecting regions
2: allow user to define only the changes they require in the config file by inheriting the default (config.conf)